### PR TITLE
Handle exceptions

### DIFF
--- a/evernote-sdk-js/thrift/lib/node/thrift-node-binary.js
+++ b/evernote-sdk-js/thrift/lib/node/thrift-node-binary.js
@@ -102,7 +102,11 @@ exports.NodeBinaryHttpTransport = function(url) {
           pos += data[i].length;
         }
         self.received = bufferToArrayBuffer(buffer);
-        callback(recv_method.call(client));
+        try {
+          callback(recv_method.call(client));
+        } catch(e) {
+          onerror(e);
+        }
       });
     });
 


### PR DESCRIPTION
When a service invocation throws an exception like a `EDAMUserException` the error callback is not called, causing your node.js application to crash. This fix just handles exceptions and passes then to the `onerror` callback.
