### PR TITLE
Added manifest for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,1 @@
+package.json


### PR DESCRIPTION
Afterwards this package can be added to bower with: `bower register evernote-sdk-js https://github.com/evernote/evernote-sdk-js`
