### PR TITLE
Reset offset to 0 after reading thrift message.

### DIFF
--- a/evernote-sdk-js/thrift/lib/thrift-binary.js
+++ b/evernote-sdk-js/thrift/lib/thrift-binary.js
@@ -297,6 +297,7 @@ Thrift.BinaryParser = {
     };
     
     p.readMessageEnd = function () {
+        this.transport.offset = 0;
     };
     
     p.readStructBegin = function () {


### PR DESCRIPTION
The offset on the transport layer was not being reset properly after reading a message, this was causing [RangeError: byteOffset out of range.]
