### PR TITLE
Fixed error with latest version of less-middleware

### DIFF
--- a/sample/express/app.js
+++ b/sample/express/app.js
@@ -23,7 +23,7 @@ app.configure(function(){
   });
 
   app.use(app.router);
-  app.use(require('less-middleware')({src: __dirname + '/public'}));
+  app.use(require('less-middleware')(__dirname + '/public'));
   app.use(express.static(path.join(__dirname, 'public')));
 });
 


### PR DESCRIPTION
Old syntax was giving an error when trying to GET stylesheets:

HTTP 500: TypeError: Path must be a string. Received { src: '/Users/jamesgupta/Downloads/evernote-sdk-js-master/sample/express/public' }

Updated code to new less-middleware syntax and works fine!