### PR TITLE
Fix bug - allow http OR https connections

### DIFF
--- a/src/thrift/transport/binaryHttpTransport.js
+++ b/src/thrift/transport/binaryHttpTransport.js
@@ -23,7 +23,6 @@ var url = require('url');
 
 function BinaryHttpTransport (serviceUrl, quiet) {
     var parsedUrl = url.parse(serviceUrl);
-    this.protocol = parsedUrl.protocol;
     this.hostname = parsedUrl.hostname;
     this.port = parsedUrl.port;
     this.path = parsedUrl.path;
@@ -58,7 +57,7 @@ BinaryHttpTransport.prototype.clear = function () {
 BinaryHttpTransport.prototype.flush = function (callback) {
     var me = this;
     var options = {
-        protocol: this.protocol,
+        protocol: "https:",
         hostname: this.hostname,
         port: this.port,
         path: this.path,

--- a/src/thrift/transport/binaryHttpTransport.js
+++ b/src/thrift/transport/binaryHttpTransport.js
@@ -23,6 +23,7 @@ var url = require('url');
 
 function BinaryHttpTransport (serviceUrl, quiet) {
     var parsedUrl = url.parse(serviceUrl);
+    this.protocol = parsedUrl.protocol;
     this.hostname = parsedUrl.hostname;
     this.port = parsedUrl.port;
     this.path = parsedUrl.path;
@@ -57,6 +58,7 @@ BinaryHttpTransport.prototype.clear = function () {
 BinaryHttpTransport.prototype.flush = function (callback) {
     var me = this;
     var options = {
+        protocol: this.protocol,
         hostname: this.hostname,
         port: this.port,
         path: this.path,

--- a/src/thrift/transport/binaryHttpTransport.js
+++ b/src/thrift/transport/binaryHttpTransport.js
@@ -57,7 +57,7 @@ BinaryHttpTransport.prototype.clear = function () {
 BinaryHttpTransport.prototype.flush = function (callback) {
     var me = this;
     var options = {
-        protocol: "https:",
+        protocol: 'https:',
         hostname: this.hostname,
         port: this.port,
         path: this.path,


### PR DESCRIPTION
With this change it is possible to connect to http or https evernote servers - which one is specified in URL.