### PR TITLE
Force https client

### DIFF
--- a/src/thrift/transport/binaryHttpTransport.js
+++ b/src/thrift/transport/binaryHttpTransport.js
@@ -18,7 +18,7 @@
  */
 
 var MemBuffer = require('./memBuffer');
-var http = require('http');
+var http = require('https');
 var url = require('url');
 
 function BinaryHttpTransport (serviceUrl, quiet) {


### PR DESCRIPTION
Fixes #81. 
According to the PR #69, the https value has hardcoded. But from what I read (Ex: https://stackoverflow.com/questions/34147372/node-js-error-protocol-https-not-supported-expected-http) the http client also needs to be changed to ```htttp = require('https')```.

Its kinda strange to have two different modules, one for doing http and other for https requests, but it solves the problem.