### PR TITLE
Catch readMessageBegin failures

### DIFF
--- a/src/thrift/thrift.js
+++ b/src/thrift/thrift.js
@@ -182,7 +182,16 @@ Thrift.Method.prototype.processResponse = function (response, callback) {
 
     callback = callback || Thrift.Method.noop;
 
-    var header = response.readMessageBegin();
+    try {
+      header = response.readMessageBegin();
+    }
+    catch (exception) {
+      err = Error('Failed to readMessageBegin. Received [' + exception + ']');
+      response.readMessageEnd();
+      callback(err);
+      return;
+    }
+
     if (header.mtype == Thrift.MessageType.EXCEPTION) {
         err = Thrift.TApplicationException.read(response);
         response.readMessageEnd();


### PR DESCRIPTION
Refs. #71 

This patch is intended to fix uncaught exceptions triggered by a MemBuffer overrun exception.

```
2018-04-27T19:37:13.755+0000 - uncaughtException: Error: MemBuffer overrun
    at MemBuffer.read (/[redacted]/[redacted]/node_modules/evernote/lib/thrift/transport/memBuffer.js:29:55)
    at BinaryProtocol.readMessageBegin (/[redacted]/[redacted]/node_modules/evernote/lib/thrift/protocol/binaryProtocol.js:203:38)
    at Thrift.Method.processResponse (/[redacted]/[redacted]/node_modules/evernote/lib/thrift/thrift.js:184:27)
    at Thrift.Method.<anonymous> (/[redacted]/[redacted]/node_modules/evernote/lib/thrift/thrift.js:165:42)
    at wrapTransport (/[redacted]/[redacted]/node_modules/evernote/lib/thrift/protocol/binaryProtocol.js:48:20)
    at IncomingMessage.<anonymous> (/[redacted]/[redacted]/node_modules/evernote/lib/thrift/transport/binaryHttpTransport.js:82:27)
    at IncomingMessage.emit (events.js:185:15)
    at endReadableNT (_stream_readable.js:1106:12)
    at process._tickCallback (internal/process/next_tick.js:178:19)
```