### PR TITLE
Removing extra slash from '/edam/user'

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -96,7 +96,7 @@ class Client {
     if (!this._userStore) {
       this._userStore = new UserStoreClient({
         token: this.token,
-        url: this.getEndpoint('/edam/user'),
+        url: this.getEndpoint('edam/user'),
       });
     }
     return this._userStore;


### PR DESCRIPTION
Client.getEndpoint receives a path in order to create the complete URL to which the request is sent, but since it is already appending '/' to the end of the base URL, then the path should not have '/' at the beginning.